### PR TITLE
Add 2014_monthly_sales_per_item_pivot and transaction_update_salariedflag

### DIFF
--- a/SQL/2014_monthly_sales_per_item_pivot.sql
+++ b/SQL/2014_monthly_sales_per_item_pivot.sql
@@ -1,0 +1,41 @@
+/*
+Returns a pivot table showing the total units sold in each month of 2014 for each ProductID
+*/
+
+SELECT 
+	ProductID AS 'ProductID'
+,	[1] AS 'Jan'
+,	[2] AS 'Feb'
+,	[3] AS 'Mar'
+,	[4] AS 'Apr'
+,	[5] AS 'May'
+,	[6] AS 'Jun'
+,	[7] AS 'Jul'
+,	[8] AS 'Aug'
+,	[9] AS 'Sep'
+,	[10] AS 'Oct'
+,	[11] AS 'Nov'
+,	[12] AS 'Dec'
+
+FROM 
+(SELECT 
+	SOD.ProductID AS 'ProductID'
+,	SUM(SOD.OrderQty) AS 'OrderQty'
+,	MONTH(SOH.ShipDate) AS 'ShipMonth'
+FROM
+	Sales.SalesOrderDetail AS SOD
+JOIN 
+	Sales.SalesOrderHeader AS SOH
+	ON SOD.SalesOrderID = SOH.SalesOrderID
+WHERE 
+	YEAR(SOH.ShipDate) = 2014
+GROUP BY 
+	SOD.ProductId
+,	MONTH(SOH.ShipDate)
+) Sales
+PIVOT
+(
+SUM(OrderQty)
+FOR ShipMonth IN ([1],[2],[3],[4],[5],[6],[7],[8],[9],[10],[11],[12])
+) AS pvt 
+ORDER BY pvt.ProductID;

--- a/SQL/transaction_update_salariedflag.sql
+++ b/SQL/transaction_update_salariedflag.sql
@@ -1,0 +1,28 @@
+DROP TABLE IF EXISTS #TempHumanResourcesEmployee;
+
+SELECT *
+INTO #TempHumanResourcesEmployee
+FROM HumanResources.Employee;
+
+BEGIN TRANSACTION; 
+
+DECLARE @NewSalary TABLE (Id BIGINT)
+INSERT INTO @NewSalary(Id) VALUES (4),(11),(12),(13)
+
+UPDATE #TempHumanResourcesEmployee
+	SET SalariedFlag = 1
+	WHERE BusinessEntityID IN (SELECT * FROM @NewSalary);
+
+SELECT 
+	BusinessEntityID
+,	SalariedFlag 
+FROM 
+	#TempHumanResourcesEmployee;
+
+ROLLBACK TRANSACTION;
+
+SELECT 
+	BusinessEntityID
+,	SalariedFlag 
+FROM 
+	#TempHumanResourcesEmployee;


### PR DESCRIPTION
2014_monthly_sales_per_item_pivot demonstrates pivoting in SQL, but may need to be renamed to distinguish units sold from sale value.

transaction_update_salariedflag demonstrates creating a temp table and using a transaction to update it as a means of testing the update safely.  